### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rate-limit-monitor.yml
+++ b/.github/workflows/rate-limit-monitor.yml
@@ -1,5 +1,9 @@
 name: Monitor GitHub API Rate Limit
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   schedule:
     - cron: "0 0 * * *" # Runs daily at midnight


### PR DESCRIPTION
Potential fix for [https://github.com/DataJourneyHQ/DataJourney/security/code-scanning/3](https://github.com/DataJourneyHQ/DataJourney/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow:
- `contents: read` is required to fetch rate limit information using the GitHub API.
- `actions: write` is required to upload artifacts.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the specific job (`check-rate-limit`) to limit permissions to that job only. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
