### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -1,7 +1,8 @@
 # configures to run for two repos (matrix format)
 name: github-repo-stats
 concurrency: github-repo-stats
-
+permissions:
+  contents: read
 on:
   schedule:
     - cron: "50 23 * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/DataJourneyHQ/DataJourney/security/code-scanning/2](https://github.com/DataJourneyHQ/DataJourney/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the root of the workflow. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's purpose (generating repository statistics), it likely only needs `contents: read` permission. If additional permissions are required (e.g., for writing pull requests or issues), they can be added explicitly.

The `permissions` block will be added at the root level, applying to all jobs in the workflow. This ensures consistency and avoids the need to define permissions for each job individually.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
