### PR TITLE
Reviews CI: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,4 +1,6 @@
 name: Lint prose
+permissions:
+  contents: read
 on:
   pull_request:
 


### PR DESCRIPTION
Potential fix for [https://github.com/DataJourneyHQ/DataJourney/security/code-scanning/4](https://github.com/DataJourneyHQ/DataJourney/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Since the workflow is performing a linting operation and does not appear to require write access, we will set `contents: read` as the permission. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
